### PR TITLE
feature/error-handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For overkill and practice, I dockerized the scripts: [password-generator image o
 
 ### Use Image
 
-`$ docker run devmegan/password-generator:1.0.0 <length:int> <complexity:str[low|medium|high]>`
+`$ docker run devmegan/password-generator:latest <length:int> <complexity:str[low|medium|high]>`
 
 ### Use Dockerfile
 

--- a/generate.sh
+++ b/generate.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [[ $# -lt 2 ]]; then
+    echo "./generate.sh requires at least 2 arguments"
+    echo
+    echo "Usage: $0 <length:int> <characters:str[low|medium|high]>"
+
+    exit 1
+fi
+
 php -r '
     require_once "oop-generate.php";
     $password = new PasswordGenerator('$1', "'$2'");

--- a/generate.sh
+++ b/generate.sh
@@ -8,6 +8,17 @@ if [[ $# -lt 2 ]]; then
     exit 1
 fi
 
+if [[ ! $1 =~ ^[0-9]+$ || ! $2 =~ ^(low|medium|high)$ ]]; then
+    echo "./generate.sh requires arguments in the following format arguments"
+    echo
+    echo "Usage: $0 <length:int> <characters:str[low|medium|high]>"
+    echo
+    echo "    length      : positive integer for length of password."
+    echo "    complexity  : 'low', 'medium', or 'high' for the complexity of the password."
+
+    exit 1
+fi
+
 php -r '
     require_once "oop-generate.php";
     $password = new PasswordGenerator('$1', "'$2'");


### PR DESCRIPTION
## Added
- [6175958](https://github.com/devmegan/password-generator/commit/61759581e69ec7e40e405ef3606d674ed0361f07) Add error handling to ensure that the bash script requires at least 2 arguments.
- [34f1b3c](https://github.com/devmegan/password-generator/commit/34f1b3c9ca81dad3c6da3f6ed98c6137496901d9) Add error handling to ensure that the bash script arguments are in the correct format.

## Changed
- [devmegan/password-generator:1.1.0](https://hub.docker.com/layers/devmegan/password-generator/1.1.0/images/sha256-8391658f72b033f9d091c2133c23a188a624e1c9f8a52f6f24ddf663edc62006?context=explore) Updated Docker image to include new changes